### PR TITLE
KMA-40 - create score from content

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -30,3 +30,51 @@
 .keyword-label {
   font-weight: bold;
 }
+
+.modals {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100%;
+}
+.modal-wrapper{
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+  background: rgba(0,0,0,0.3);
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.modal {
+  width: 200px;
+  background: #fff;
+  border-radius: 5px;
+  min-width: 500px;
+  position: relative;
+}
+
+.modal-content {
+  background: rgba(193, 29, 29,0.5);
+  color: #fff;
+  height: 150px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modals .close {
+  position: absolute !important;
+  bottom: 12px;
+  right: 50px;
+  background-color: transparent;
+  font-size: 2em;
+}
+
+.modalUri {
+  width: 300px !important;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import { ContentList } from './content'
 import { ApiUserShow, ApiUserEdit, ApiUserCreate } from './apiUser'
 import restClient from './restClient'
 import Dashboard from './dashboard'
+import customReducer from './reducer'
 
 const App = () => (
   <Admin
@@ -16,7 +17,8 @@ const App = () => (
     authClient={authClient}
     loginPage={loginPage}
     restClient={restClient}
-    dashboard={Dashboard}>
+    dashboard={Dashboard}
+    customReducers={{customReducer}}>
     <Resource name='scores' list={ScoreList} />
     <Resource name='score' show={ScoreShow} edit={ScoreEdit} create={ScoreCreate} />
     <Resource name='content' list={ContentList} options={{ label: 'Content' }} />

--- a/src/ModalContainer.js
+++ b/src/ModalContainer.js
@@ -32,8 +32,8 @@ class Modal extends Component {
           <div className='modal'>
             <div className='text'>{text}</div>
             <div className='buttons'>
-              <button className='modal-button' onClick={() => this.onConfirm()}>{confirmationText || 'Confirm'}</button>
               <button className='modal-button' onClick={() => this.onClose()}>{closeText || 'Close'}</button>
+              <button className='modal-button' onClick={() => this.onConfirm()}>{confirmationText || 'Confirm'}</button>
             </div>
           </div>
         </div>

--- a/src/ModalContainer.js
+++ b/src/ModalContainer.js
@@ -1,0 +1,84 @@
+/*
+ * Modified from https://github.com/hurkanyakay/react-redux-modals
+ */
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import * as actions from './actions'
+import FlatButton from 'material-ui/FlatButton'
+
+class Modal extends Component {
+  onClose(){
+    if (this.props.item.onClose) {
+      this.props.item.onClose()
+      this.props.onClose(this.props.item)
+    } else {
+      this.props.onClose(this.props.item)
+    }
+  }
+  onConfirm(){
+    if (this.props.item.onConfirm) {
+      this.props.item.onConfirm()
+      this.props.onClose(this.props.item)
+    }
+  }
+  render() {
+    const { zIndex } = this.props
+    const { type } = this.props.item
+    if (type === 'confirmation') {
+      const { text, confirmationText, closeText } = this.props.item
+      return (
+        <div className='modal-wrapper' style={{zIndex: (zIndex + 1) * 10}}>
+          <div className='modal'>
+            <div className='text'>{text}</div>
+            <div className='buttons'>
+              <button className='modal-button' onClick={() => this.onConfirm()}>{confirmationText || 'Confirm'}</button>
+              <button className='modal-button' onClick={() => this.onClose()}>{closeText || 'Close'}</button>
+            </div>
+          </div>
+        </div>
+      )
+    } else if (type === 'custom') {
+      const { content, closeText } = this.props.item
+      return (
+        <div className='modal-wrapper' style={{zIndex: (zIndex + 1) * 10}}>
+          <div className='modal'>
+            <FlatButton secondary className='close' label={closeText || 'Close'} onClick={() => this.onClose()} />
+            {content}
+          </div>
+        </div>
+      )
+    }
+    return (
+        <div></div>
+    )
+  }
+}
+
+class Modals extends Component {
+  render() {
+    let modals
+    if (this.props.modals) {
+      modals = this.props.modals.map((item, i) =>
+        <Modal item={item} key={i} zIndex={i} onClose={(item) => this.props.closeModal(item)} />)
+      }
+    return (
+      <div className='modals'>
+        {modals}
+      </div>
+    )
+  }
+}
+
+const ModalContainer = connect(
+  function mapStateToProps(state) {
+    return {
+      modals: state.customReducer.modals
+    }
+  },
+  function mapDispatchToProps(dispatch) {
+    return bindActionCreators(actions, dispatch)
+  }
+)(Modals)
+
+export default ModalContainer

--- a/src/TooltipTextInput.js
+++ b/src/TooltipTextInput.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import TextField from 'material-ui/TextField'
 
-const TooltipTextInput = ({ input, label, meta: { touched, error }, ...custom }) => (
+const TooltipTextInput = ({ input, label, meta: { touched, error }, className, ...custom }) => (
   <div style={{width: '256px'}} data-tip>
     <TextField
       hintText={label}
       floatingLabelText={label}
       errorText={touched && error}
+      className={className}
       {...input} />
   </div>
 )

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,0 +1,12 @@
+export const openModal = (obj) => {
+  return {
+    type: 'OPEN_MODAL',
+    obj,
+  }
+}
+export const closeModal = (obj) => {
+  return {
+    type: 'CLOSE_MODAL',
+    obj,
+  }
+}

--- a/src/content.js
+++ b/src/content.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { List, Datagrid, UrlField, TextInput, Filter } from 'admin-on-rest'
 import CreateScoreButton from './scores/CreateScoreButton'
+import ModalContainer from './ModalContainer'
 
 const ContentFilter = (props) => (
   <Filter {...props}>
@@ -9,10 +10,13 @@ const ContentFilter = (props) => (
 )
 
 export const ContentList = (props) => (
-  <List title='Content Without Scores' {...props} filters={<ContentFilter />} perPage={25}>
-    <Datagrid>
-      <UrlField source='id' label='URI' />
-      <CreateScoreButton />
-    </Datagrid>
-  </List>
+  <div>
+    <ModalContainer />
+    <List title='Content Without Scores' {...props} filters={<ContentFilter />} perPage={25}>
+      <Datagrid>
+        <UrlField source='id' label='URI' />
+        <CreateScoreButton />
+      </Datagrid>
+    </List>
+  </div>
 )

--- a/src/content.js
+++ b/src/content.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { List, Datagrid, UrlField, TextInput, Filter } from 'admin-on-rest'
+import CreateScoreButton from './scores/CreateScoreButton'
 
 const ContentFilter = (props) => (
   <Filter {...props}>
@@ -11,6 +12,7 @@ export const ContentList = (props) => (
   <List title='Content Without Scores' {...props} filters={<ContentFilter />} perPage={25}>
     <Datagrid>
       <UrlField source='id' label='URI' />
+      <CreateScoreButton />
     </Datagrid>
   </List>
 )

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,0 +1,21 @@
+const initialState = {
+  modals: []
+}
+
+function reducer(state = initialState, action) {
+  switch (action.type) {
+    case 'OPEN_MODAL':
+      return {
+        ...state,
+        modals: state.modals.concat(action.obj)
+      }
+    case 'CLOSE_MODAL':
+      return {
+        ...state,
+        modals: state.modals.filter(item => item.id !== action.obj.id)
+      }
+    default:
+      return state
+  }
+}
+export default reducer

--- a/src/score.js
+++ b/src/score.js
@@ -71,7 +71,7 @@ const CreateScoreActions = ({ basePath, data }) => (
 export const ScoreCreate = (props) => (
   <Create title='Create Score' actions={<CreateScoreActions />} {...props}>
     <SimpleForm redirect='show' validate={validateScore}>
-      <TooltipTextInput label='URI' source='id' />
+      <TooltipTextInput label='URI' source='id' input={{value: parseQuery(window.location.hash).id}} />
       <ReactTooltip place='right' type='info' delayHide={1000} effect='solid'>
         <p>
           Events are identified in our system by their URI. For Web Pages, the URI is simply the full URL.<br />
@@ -84,3 +84,13 @@ export const ScoreCreate = (props) => (
     </SimpleForm>
   </Create>
 )
+
+function parseQuery (queryString) {
+  let query = {}
+  const pairs = (queryString[0] === '#' ? queryString.substr(queryString.indexOf('?') + 1) : queryString).split('&')
+  for (var i = 0; i < pairs.length; i++) {
+    var pair = pairs[i].split('=')
+    query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '')
+  }
+  return query
+}

--- a/src/score.js
+++ b/src/score.js
@@ -71,7 +71,7 @@ const CreateScoreActions = ({ basePath, data }) => (
 export const ScoreCreate = (props) => (
   <Create title='Create Score' actions={<CreateScoreActions />} {...props}>
     <SimpleForm redirect='show' validate={validateScore}>
-      <TooltipTextInput label='URI' source='id' input={{value: parseQuery(window.location.hash).id}} />
+      <TooltipTextInput label='URI' source='id' />
       <ReactTooltip place='right' type='info' delayHide={1000} effect='solid'>
         <p>
           Events are identified in our system by their URI. For Web Pages, the URI is simply the full URL.<br />
@@ -84,13 +84,3 @@ export const ScoreCreate = (props) => (
     </SimpleForm>
   </Create>
 )
-
-function parseQuery (queryString) {
-  let query = {}
-  const pairs = (queryString[0] === '#' ? queryString.substr(queryString.indexOf('?') + 1) : queryString).split('&')
-  for (var i = 0; i < pairs.length; i++) {
-    var pair = pairs[i].split('=')
-    query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '')
-  }
-  return query
-}

--- a/src/scores/CreateScoreButton.js
+++ b/src/scores/CreateScoreButton.js
@@ -2,13 +2,20 @@ import React, { Component } from 'react'
 import FlatButton from 'material-ui/FlatButton'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { push as pushAction } from 'react-router-redux'
 import ContentCreateIcon from 'material-ui/svg-icons/content/create'
+import ScoreCreate from './CreateScoreModal'
+import * as actions from '../actions'
 
 class CreateScoreButton extends Component {
   handleClick = () => {
-    const { push, record } = this.props
-    push('/score/create?id=' + encodeURIComponent(record.id))
+    const { dispatch, record } = this.props
+    return dispatch(actions.openModal({
+      id: record.id,
+      type: 'custom',
+      content: <ScoreCreate resource='score' location={window.location} item={record} />,
+      onClose: () => {},
+      closeText: 'Cancel'
+    }))
   }
 
   render () {
@@ -17,10 +24,14 @@ class CreateScoreButton extends Component {
 }
 
 CreateScoreButton.propTypes = {
-  push: PropTypes.func,
   record: PropTypes.object
 }
 
-export default connect(null, {
-  push: pushAction
-})(CreateScoreButton)
+export default connect(
+  null,
+  function mapDispatchToProps(dispatch) {
+    return {
+      dispatch
+    }
+  }
+)(CreateScoreButton)

--- a/src/scores/CreateScoreButton.js
+++ b/src/scores/CreateScoreButton.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react'
+import FlatButton from 'material-ui/FlatButton'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { push as pushAction } from 'react-router-redux'
+import ContentCreateIcon from 'material-ui/svg-icons/content/create'
+
+class CreateScoreButton extends Component {
+  handleClick = () => {
+    const { push, record } = this.props
+    push('/score/create?id=' + encodeURIComponent(record.id))
+  }
+
+  render () {
+    return <FlatButton label='Create' icon={<ContentCreateIcon />} onClick={this.handleClick} />
+  }
+}
+
+CreateScoreButton.propTypes = {
+  push: PropTypes.func,
+  record: PropTypes.object
+}
+
+export default connect(null, {
+  push: pushAction
+})(CreateScoreButton)

--- a/src/scores/CreateScoreModal.js
+++ b/src/scores/CreateScoreModal.js
@@ -1,0 +1,88 @@
+import React, { Component } from 'react'
+import { Create, SimpleForm, SelectInput, CREATE, refreshView, showNotification } from 'admin-on-rest'
+import ReactTooltip from 'react-tooltip'
+import TooltipTextInput from '../TooltipTextInput'
+import { PartialMap } from '../scores/scoreMap'
+import { connect } from 'react-redux'
+import * as actions from '../actions'
+import PropTypes from 'prop-types'
+import restClient from '../restClient'
+
+const validateScore = (record) => {
+  const errors = {}
+  const score = record.score
+
+  if (!record.id) {
+    errors.id = 'URI is required'
+  }
+
+  if (score === undefined) {
+    errors.score = 'Score values are required'
+    return errors
+  }
+
+  if (score < 0 || score > 8) {
+    errors.score = 'Audience must be one of the given options'
+  }
+
+  return errors
+}
+
+class CreateScoreModal extends Component {
+  onSubmit = async () => {
+    const { dispatch, item, resource, form } = this.props
+    const recordForm = form['record-form']
+
+    if (!recordForm.syncErrors) {
+      await restClient(CREATE, resource, {data: {id: item.id, score: recordForm.values.score}})
+      await dispatch(refreshView())
+      return dispatch(actions.closeModal({
+        id: item.id,
+        type: 'custom',
+        onClose: () => {},
+      }))
+    } else {
+      let errorMessage = recordForm.syncErrors.score || recordForm.syncErrors.id || ''
+      return dispatch(showNotification(errorMessage, 'warning'))
+    }
+  }
+
+  render() {
+    const props = this.props
+
+    return (
+      <Create title='Create Score' {...props}>
+        <SimpleForm validate={validateScore} handleSubmit={() => this.onSubmit}>
+          <TooltipTextInput className='modalUri' label='URI' source='id' defaultValue={props.item.id} />
+          <ReactTooltip place='right' type='info' delayHide={1000} effect='solid'>
+            <p>
+              Events are identified in our system by their URI. For Web Pages, the URI is simply the full URL.<br />
+              URIs for other types of products may need to be defined by the Growth Solutions Team.<br />
+              If you are unsure about the structure of the URI for your event please contact the
+              Growth Solutions Team at <a href='mailto:dps-growthsolutions@cru.org'>dps-growthsolutions@cru.org</a>.
+            </p>
+          </ReactTooltip>
+          <SelectInput label='Audience' source='score' choices={PartialMap()} />
+        </SimpleForm>
+      </Create>
+    )
+  }
+}
+
+CreateScoreModal.propTypes = {
+  record: PropTypes.object,
+  form: PropTypes.object
+}
+
+export default connect(
+  function mapStateToProps(state, props) {
+    return ({
+      form: state.form
+    })
+  },
+  function mapDispatchToProps(dispatch) {
+    return {
+      dispatch
+    }
+  }
+)(CreateScoreModal)


### PR DESCRIPTION
This PR makes a `Create` button on the un-scored content list page (one button per row) which opens a modal window with the URI populated for easy bulk scoring.

![screen shot 2018-06-22 at 3 13 32 pm](https://user-images.githubusercontent.com/2905714/41794879-e06fdc80-762e-11e8-81cd-42a878b9fd90.png)

![screen shot 2018-06-22 at 3 13 39 pm](https://user-images.githubusercontent.com/2905714/41794886-e53f5894-762e-11e8-9d46-342b1235921d.png)
