### PR TITLE
Encoded uri handling

### DIFF
--- a/src/restClient.js
+++ b/src/restClient.js
@@ -61,8 +61,15 @@ const convertRESTRequestToHTTP = (type, resource, params) => {
       if (orderBy === 'id') {
         orderBy = 'uri'
       }
+
+      let uri = params.filter['q']
+
+      if (resource !== 'api-users' && uri.indexOf('%') === -1) {
+        uri = handleEncoding(uri)
+      }
+
       const query = {
-        uri: JSON.stringify(params.filter['q']),
+        uri: JSON.stringify(uri),
         page: params.pagination['page'],
         per_page: params.pagination['perPage'],
         order_by: orderBy,


### PR DESCRIPTION
The URIs coming in from Snowplow are not always compatible with the way this admin app handles URI encoding.

The tested URI was `ert://submit-registration/new+staff+orientation+%28nso%29+%7c+fall+2018/new+staff+member%3a+nso`

This will show up in the UI as decoded (except spaces are still `+`): `ert://submit-registration/new+staff+orientation+(nso)+|+fall+2018/new+staff+member:+nso`