### PR TITLE
KMA-58 - fix modals

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -83,3 +83,7 @@
 .modalUri {
   width: 300px !important;
 }
+
+.hidden {
+  display: none;
+}

--- a/src/ModalContainer.js
+++ b/src/ModalContainer.js
@@ -63,7 +63,7 @@ class Modals extends Component {
         <Modal item={item} key={i} zIndex={i} onClose={(item) => this.props.closeModal(item)} />)
     }
     return (
-      <div className='modals'>
+      <div className={modals.length ? 'modals' : 'modals hidden'}>
         {modals}
       </div>
     )


### PR DESCRIPTION
This fixes an issue where the `modals` div is covering the whole screen and making the URLs not click-able on the unscored content pages.