### PR TITLE
Fix malformed JWT error

### DIFF
--- a/src/authClient.js
+++ b/src/authClient.js
@@ -20,6 +20,58 @@ export const oktaAuthClient = new OktaAuth({
 // Automatically refresh access tokens using the refresh token if it expires
 oktaAuthClient.start()
 
+// Check the validity of the session token and regenerate it if necessary
+export async function authCheck () {
+  if (oktaAuthClient.isLoginRedirect()) {
+    // Extract the authorization code from the login redirect URL
+    await oktaAuthClient.handleLoginRedirect()
+  }
+
+  const sessionToken = sessionStorage.getItem('sessionToken')
+  if (sessionToken) {
+    const session = jwtDecode(sessionToken)
+    const isExpired = (new Date().getTime() / 1000) - session.exp >= 0
+
+    if (!isExpired) {
+      return
+    }
+
+    sessionStorage.removeItem('sessionToken')
+  }
+
+  const accessToken = oktaAuthClient.getAccessToken()
+  if (!accessToken) {
+    await oktaAuthClient.signInWithRedirect({
+      originalUri: window.location.href
+    })
+
+    let json = {
+      status: 401,
+      message: 'Unauthorized'
+    }
+    throw new HttpError(json.message, json.status, json)
+  }
+
+  // get JWT from API
+  return fetch(process.env.REACT_APP_API_URL + '/login', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      access_token: accessToken
+    })
+  }).then(response => {
+    if (response.status !== 200) {
+      throw new Error(response.statusText)
+    }
+    return response.json()
+  }).then((response) => {
+    // save session JWT to sessionStorage
+    sessionStorage.setItem('sessionToken', response)
+  })
+}
+
 export default async (type, params) => {
   switch (type) {
     case AUTH_LOGIN: {
@@ -42,54 +94,12 @@ export default async (type, params) => {
       return Promise.resolve()
     }
     case AUTH_CHECK: {
-      if (oktaAuthClient.isLoginRedirect()) {
-        // Extract the authorization code from the login redirect URL
-        await oktaAuthClient.handleLoginRedirect()
-      }
-
-      const sessionToken = sessionStorage.getItem('sessionToken')
-      if (sessionToken) {
-        const session = jwtDecode(sessionToken)
-        const isExpired = (new Date().getTime() / 1000) - session.exp >= 0
-
-        if (!isExpired) {
-          return
-        }
-
-        sessionStorage.removeItem('sessionToken')
-      }
-
-      const accessToken = oktaAuthClient.getAccessToken()
-      if (!accessToken) {
-        await oktaAuthClient.signInWithRedirect({
-          originalUri: window.location.href
-        })
-
-        let json = {
-          status: 401,
-          message: 'Unauthorized'
-        }
-        throw new HttpError(json.message, json.status, json)
-      }
-
-      // get JWT from API
-      return fetch(process.env.REACT_APP_API_URL + '/login', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          access_token: accessToken
-        })
-      }).then(response => {
-        if (response.status !== 200) {
-          throw new Error(response.statusText)
-        }
-        return response.json()
-      }).then((response) => {
-        // save session JWT to sessionStorage
-        sessionStorage.setItem('sessionToken', response)
-      })
+      // admin-on-rest immediately starts rendering, even if we return a promise that eventually
+      // rejects. Instead of being able to delay rendering in AUTH_CHECK until we verify and
+      // asynchronously refresh the session token if necessary, we instead have to introduce that
+      // delay in restClient.js
+      // https://github.com/marmelab/admin-on-rest/blob/980a73f474a5bd87a717da2cb6f2fd8aaef1b8f7/src/auth/Restricted.js#L43-L53
+      return
     }
     default: {
       let json = {

--- a/src/authClient.test.js
+++ b/src/authClient.test.js
@@ -1,6 +1,6 @@
 /* global sessionStorage */
-import { AUTH_LOGOUT, AUTH_ERROR, AUTH_CHECK } from 'admin-on-rest'
-import authClient, { oktaAuthClient } from './authClient'
+import { AUTH_LOGOUT, AUTH_ERROR } from 'admin-on-rest'
+import authClient, { authCheck, oktaAuthClient } from './authClient'
 
 const futureJwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1MjQyNDgzNTQ5OTk5fQ.DJI5Gx73hrueIQFi_FAZhTgUj4cRXSumJTySkcbgGYc'
 const pastJwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1MjQyNDY3fQ.Lh-B5ehegw4KXRki62b-vDgPkdEfG-PSeIDpVQuAfgg'
@@ -80,7 +80,7 @@ describe('Auth Check', () => {
     sessionStorage.getItem.mockReturnValueOnce(futureJwt)
     oktaAuthClient.signInWithRedirect = jest.fn(() => Promise.resolve())
 
-    authClient(AUTH_CHECK, {}).then(() => {
+    authCheck().then(() => {
       expect(sessionStorage.getItem.mock.calls[0][0]).toEqual('sessionToken')
       expect(sessionStorage.removeItem.mock.calls.length).toEqual(0)
       expect(oktaAuthClient.signInWithRedirect).not.toHaveBeenCalled()
@@ -97,7 +97,7 @@ describe('Auth Check', () => {
     global.fetch
       .mockReturnValueOnce(Promise.resolve(mockApiResponse))
 
-    authClient(AUTH_CHECK, {}).then(() => {
+    authCheck().then(() => {
       expect(sessionStorage.getItem.mock.calls.length).toEqual(1)
       expect(sessionStorage.getItem.mock.calls[0][0]).toEqual('sessionToken')
       expect(sessionStorage.removeItem.mock.calls.length).toEqual(1)
@@ -114,7 +114,7 @@ describe('Auth Check', () => {
     global.fetch
       .mockReturnValueOnce(Promise.resolve(mockApiResponse))
 
-    authClient(AUTH_CHECK, {}).then(() => {
+    authCheck().then(() => {
       expect(sessionStorage.setItem.mock.calls.length).toEqual(1)
       expect(sessionStorage.setItem.mock.calls[0][0]).toEqual('sessionToken')
       done()
@@ -134,7 +134,7 @@ describe('Auth Check', () => {
     global.fetch
       .mockReturnValueOnce(Promise.resolve(failedApiResponse))
 
-    authClient(AUTH_CHECK, {}).then(() => {}, (error) => {
+    authCheck().then(() => {}, (error) => {
       expect(error).toBeDefined()
       expect(error.message).toEqual(failedApiResponse.statusText)
       done()
@@ -147,7 +147,7 @@ describe('Auth Check', () => {
     oktaAuthClient.getAccessToken = jest.fn(() => null)
     oktaAuthClient.signInWithRedirect = jest.fn(() => Promise.resolve())
 
-    authClient(AUTH_CHECK, {}).then(() => {}, () => {
+    authCheck().then(() => {}, () => {
       expect(oktaAuthClient.signInWithRedirect).toHaveBeenCalledTimes(1)
       done()
     })


### PR DESCRIPTION
admin-on-rest wasn't waiting for the auth check to finish before sending the request. It was calling authClient, which would remove the session token if it was expired, then the rest client would make the request with a null session token, then the login request would come back with the refreshed session token. I changed the rest client to wait for the session token to refresh before making the request.